### PR TITLE
Removed info about build support on Visual Studio 2015

### DIFF
--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -170,7 +170,7 @@
     <h2>Build Notes</h2>
 
     <ul>
-      <li><a href="https://visualstudio.com" target="_blank">Visual Studio 2017</a> or greater is recommended. Can also be built using Visual Studio 2015 using <a href="https://www.nuget.org/packages/Microsoft.Net.Compilers" rel="nofollow">Microsoft.Net.Compilers</a> nuget package to support compilation of C# 7.</li>
+      <li><a href="https://visualstudio.com" target="_blank">Visual Studio 2017</a> or greater is recommended.</li>
       <li>.Net Framework v4.6.1 is required.</li>
       <li>For detailed information, see <a routerLink="/build">Building</a>.</li>
     </ul>


### PR DESCRIPTION
Due to use of PackageReference the code can no longer be built on Visual Studio 2015